### PR TITLE
Add post recommendation UI

### DIFF
--- a/src/components/information_menu.rs
+++ b/src/components/information_menu.rs
@@ -1,4 +1,8 @@
 use yew::prelude::*;
+use yew_router::prelude::*;
+
+use crate::components::post_recommendation::*;
+use crate::Route;
 
 #[derive(Clone, serde::Deserialize)]
 struct AccordionItem {
@@ -12,46 +16,56 @@ pub fn information_menu() -> Html {
         serde_json::from_str::<Vec<AccordionItem>>(crate::ACCORDION_JSON)
             .expect("wrong ACCORDION_JSON format")
     });
+    let route = use_route::<Route>();
+    let recommendation = if let Some(Route::Post { id, .. }) = route {
+        html! { <div class="mt-3"><PostRecommendation id={ id } /></div> }
+    } else {
+        html! { <></> }
+    };
+
     html! {
-        <div class="accordion" id="accordionMain">
-            {
-                accordion_items.iter().enumerate().map(|(index, item)| {
-                    let item = item.clone();
-                    let id = format!("collapse{index}");
-                    let target = format!("#collapse{index}");
-                    let expanded;
-                    let mut button_classes = vec!["accordion-button"];
-                    let mut content_classes = vec!["accordion-collapse", "collapse"];
-                    if index == 0 {
-                        expanded = "true";
-                        content_classes.push("show");
-                    } else {
-                        expanded = "false";
-                        button_classes.push("collapsed");
-                    };
-                    html! {
-                        <div class="accordion-item">
-                            <h2 class="accordion-header">
-                                <button
-                                    class={ button_classes }
-                                    type="button"
-                                    data-bs-toggle="collapse"
-                                    data-bs-target={ target }
-                                    aria-expanded={ expanded }
-                                    aria-controls={ id.clone() }
-                                >
-                                    { item.title }
-                                </button>
-                            </h2>
-                            <div { id } class={ content_classes } data-bs-parent="#accordionMain">
-                                <div class="accordion-body">
-                                    { Html::from_html_unchecked(AttrValue::from(item.body)) }
+        <>
+            <div class="accordion" id="accordionMain">
+                {
+                    accordion_items.iter().enumerate().map(|(index, item)| {
+                        let item = item.clone();
+                        let id = format!("collapse{index}");
+                        let target = format!("#collapse{index}");
+                        let expanded;
+                        let mut button_classes = vec!["accordion-button"];
+                        let mut content_classes = vec!["accordion-collapse", "collapse"];
+                        if index == 0 {
+                            expanded = "true";
+                            content_classes.push("show");
+                        } else {
+                            expanded = "false";
+                            button_classes.push("collapsed");
+                        };
+                        html! {
+                            <div class="accordion-item">
+                                <h2 class="accordion-header">
+                                    <button
+                                        class={ button_classes }
+                                        type="button"
+                                        data-bs-toggle="collapse"
+                                        data-bs-target={ target }
+                                        aria-expanded={ expanded }
+                                        aria-controls={ id.clone() }
+                                    >
+                                        { item.title }
+                                    </button>
+                                </h2>
+                                <div { id } class={ content_classes } data-bs-parent="#accordionMain">
+                                    <div class="accordion-body">
+                                        { Html::from_html_unchecked(AttrValue::from(item.body)) }
+                                    </div>
                                 </div>
                             </div>
-                        </div>
-                    }
-                }).collect::<Html>()
-            }
-        </div>
+                        }
+                    }).collect::<Html>()
+                }
+            </div>
+            { recommendation }
+        </>
     }
 }

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -17,6 +17,7 @@ pub mod navigation_menu;
 pub mod optional_image;
 pub mod pagination;
 pub mod post_card;
+pub mod post_recommendation;
 pub mod search_button;
 pub mod search_field;
 pub mod simple_title_card;

--- a/src/components/post_recommendation.rs
+++ b/src/components/post_recommendation.rs
@@ -1,0 +1,111 @@
+use yew::prelude::*;
+
+use crate::components::item::*;
+use crate::components::post_card::*;
+use crate::content::*;
+use crate::utils::*;
+
+#[derive(PartialEq, Properties, Clone)]
+pub struct PostRecommendationProps {
+    pub id: u64,
+}
+
+#[function_component(PostRecommendation)]
+pub fn post_recommendation(props: &PostRecommendationProps) -> Html {
+    let PostRecommendationProps { id } = props.clone();
+    let logged_user_context = use_context::<LoggedUserContext>().unwrap();
+
+    let is_recommended = use_state_eq(|| false);
+    {
+        let is_recommended = is_recommended.clone();
+        let token = logged_user_context.token().cloned();
+        use_effect_with(id, move |id| {
+            let token = token.clone();
+            let id = *id;
+            wasm_bindgen_futures::spawn_local(async move {
+                let result = API::<PostWithRecommendedContainer>::get(OptionTokened {
+                    token,
+                    params: PostParams { id },
+                })
+                .await;
+                if let Ok(API::Success {
+                    data: PostWithRecommendedContainer { post },
+                    ..
+                }) = result
+                {
+                    is_recommended.set(post.recommended == 1);
+                }
+            });
+        });
+    }
+
+    let in_progress = use_state_eq(|| false);
+    let onclick = {
+        let in_progress = in_progress.clone();
+        let is_recommended = is_recommended.clone();
+        let logged_user_context = logged_user_context.clone();
+        let id = id;
+        Callback::from(move |e: MouseEvent| {
+            e.prevent_default();
+            if *in_progress {
+                return;
+            }
+            let Some(token) = logged_user_context.token().cloned() else {
+                return;
+            };
+            in_progress.set(true);
+            let recommend = !*is_recommended;
+            let is_recommended = is_recommended.clone();
+            let in_progress = in_progress.clone();
+            wasm_bindgen_futures::spawn_local(async move {
+                let res = API::<()>::get(Tokened {
+                    token,
+                    params: PostPoolParams { id, add: recommend },
+                })
+                .await;
+                if let Ok(API::Success { .. }) = res {
+                    is_recommended.set(recommend);
+                }
+                in_progress.set(false);
+            });
+        })
+    };
+
+    let action_button = if logged_user_context
+        .author()
+        .map(|a| a.editor == 1)
+        .unwrap_or(false)
+    {
+        html! {
+            <div class="d-grid mt-2">
+                <button type="button" class="btn btn-light" {onclick} disabled={*in_progress}>
+                    if *is_recommended {
+                        { "Удалить из рекомендаций" }
+                    } else {
+                        { "Добавить в рекомендации" }
+                    }
+                </button>
+            </div>
+        }
+    } else {
+        html! { <></> }
+    };
+
+    html! {
+        <>
+            <Item<API<PostRecommendationContainer>, PostRecommendationParams>
+                r#type={ LoadType::Params(PostRecommendationParams { id }) }
+                use_caches=true
+                component={ |post: Option<Post>| {
+                    if let Some(post) = post {
+                        html! { <PostCard post={ Some(post) } is_full=false /> }
+                    } else {
+                        html! { <></> }
+                    }
+                } }
+                error_component={ |_| html! { <></> } }
+            />
+            { action_button }
+        </>
+    }
+}


### PR DESCRIPTION
## Summary
- add components to display a recommended post and manage recommendation pool
- show recommended posts in the information sidebar
- support recommendation API interactions

## Testing
- `API_URL=http://localhost TITLE=test DESCRIPTION=desc KEYWORDS=kw ACCORDION_JSON='[]' cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6895de373f2083208e5cf8a89f4b0d3b