### PR TITLE
Add admin image upload page

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ wasm-bindgen = { version = "0.2", optional = true }
 wasm-cookies = { version = "0.2", optional = true }
 wasm-logger = { version = "0.2", optional = true }
 
-web-sys = { version = "0.3", features = ["HtmlDocument","console","Document","HtmlElement","MouseEvent","DomRect","ScrollToOptions","ScrollBehavior","Element","MouseEvent","CssStyleDeclaration","MutationObserver","MutationObserverInit","Node","CustomEvent","HtmlImageElement"], optional = true }
+web-sys = { version = "0.3", features = ["HtmlDocument","console","Document","HtmlElement","MouseEvent","DomRect","ScrollToOptions","ScrollBehavior","Element","MouseEvent","CssStyleDeclaration","MutationObserver","MutationObserverInit","Node","CustomEvent","HtmlImageElement","HtmlInputElement","File","FileList","Blob","FormData"], optional = true }
 
 gloo-history = "0.2"
 gloo = { version = "0.11", optional = true }

--- a/src/components/navigation_menu.rs
+++ b/src/components/navigation_menu.rs
@@ -78,6 +78,18 @@ pub fn navigation_menu() -> Html {
                 >
                     { "Скрытое" }
                 </Link<Route>>
+                <Link<Route>
+                    classes={
+                        classes!(
+                            "btn",
+                            "btn-light",
+                            if route == Route::UploadImage { "active" } else { "" }
+                        )
+                    }
+                    to={ Route::UploadImage }
+                >
+                    { "Загрузка изображений" }
+                </Link<Route>>
             }
         </>
     }

--- a/src/components/search_field.rs
+++ b/src/components/search_field.rs
@@ -28,6 +28,7 @@ impl SearchMode {
             | Route::UnpublishedPosts
             | Route::MyUnpublishedPosts
             | Route::HiddenPosts
+            | Route::UploadImage
             | Route::Tag { slug: _, id: _ } => Self::Posts { query: None },
             #[cfg(feature = "yandex")]
             Route::YandexToken => Self::Posts { query: None },

--- a/src/pages/mod.rs
+++ b/src/pages/mod.rs
@@ -10,6 +10,7 @@ pub mod search;
 pub mod settings;
 pub mod tag;
 pub mod unpublished_posts;
+pub mod upload_image;
 
 pub use author::*;
 pub use authors::*;
@@ -23,3 +24,4 @@ pub use search::*;
 pub use settings::*;
 pub use tag::*;
 pub use unpublished_posts::*;
+pub use upload_image::*;

--- a/src/pages/upload_image.rs
+++ b/src/pages/upload_image.rs
@@ -1,0 +1,114 @@
+use gloo_net::http::Request;
+use web_sys::{FormData, HtmlInputElement};
+use yew::prelude::*;
+
+use crate::components::meta::*;
+use crate::components::warning::*;
+use crate::utils::{LoggedUserContext, LoggedUserState};
+
+#[function_component(UploadImage)]
+pub fn upload_image() -> Html {
+    let file_input = use_node_ref();
+    let message = use_state(|| None as Option<(String, u16)>);
+    let logged_user_context = use_context::<LoggedUserContext>().unwrap();
+
+    let meta = html! { <Meta title="Загрузка изображений" noindex=true /> };
+
+    let not_auth_content = html! {
+        <>
+            { meta.clone() }
+            <Warning text="Нужна авторизация для загрузки изображений!" />
+        </>
+    };
+
+    if logged_user_context.is_not_inited() {
+        return not_auth_content;
+    }
+
+    let LoggedUserState::ActiveAndLoaded { token, author } = logged_user_context.state().clone()
+    else {
+        return not_auth_content;
+    };
+
+    if author.editor != 1 {
+        return html! {
+            <>
+                { meta.clone() }
+                <Warning text="Загрузка изображений доступна только редакторам!" />
+            </>
+        };
+    }
+
+    let on_upload = {
+        let file_input = file_input.clone();
+        let message = message.clone();
+        let token = token.clone();
+        Callback::from(move |_| {
+            let file_input = file_input.clone();
+            let message = message.clone();
+            let token = token.clone();
+            wasm_bindgen_futures::spawn_local(async move {
+                let input = match file_input.cast::<HtmlInputElement>() {
+                    Some(i) => i,
+                    None => return,
+                };
+                let files = match input.files() {
+                    Some(f) => f,
+                    None => return,
+                };
+                let file = match files.get(0) {
+                    Some(f) => f,
+                    None => return,
+                };
+                let form = match FormData::new() {
+                    Ok(f) => f,
+                    Err(_) => return,
+                };
+                form.append_with_blob_and_filename("file", &file, &file.name())
+                    .ok();
+                let req = match Request::post("/upload/image")
+                    .header("Token", &token)
+                    .body(form)
+                {
+                    Ok(r) => r,
+                    Err(err) => {
+                        message.set(Some((err.to_string(), 0)));
+                        return;
+                    }
+                };
+                match req.send().await {
+                    Ok(resp) => {
+                        let status = resp.status();
+                        let text = resp.text().await.unwrap_or_default();
+                        message.set(Some((text, status)));
+                    }
+                    Err(err) => {
+                        message.set(Some((err.to_string(), 0)));
+                    }
+                }
+            });
+        })
+    };
+
+    let prompt = if let Some((text, status)) = (*message).clone() {
+        let class = if (200..300).contains(&status) {
+            "text-success"
+        } else {
+            "text-danger"
+        };
+        html! { <p class={class}>{ text }</p> }
+    } else {
+        html! {}
+    };
+
+    html! {
+        <>
+            { meta }
+            <div class="d-flex flex-column gap-3">
+                <input type="file" ref={file_input} />
+                <button class="btn btn-light" onclick={on_upload}>{ "Загрузить" }</button>
+                { prompt }
+            </div>
+        </>
+    }
+}

--- a/src/pages/upload_image.rs
+++ b/src/pages/upload_image.rs
@@ -1,4 +1,6 @@
+#[cfg(feature = "client")]
 use gloo_net::http::Request;
+#[cfg(feature = "client")]
 use web_sys::{FormData, HtmlInputElement};
 use yew::prelude::*;
 
@@ -39,6 +41,10 @@ pub fn upload_image() -> Html {
         };
     }
 
+    #[cfg(not(feature = "client"))]
+    let on_upload = Callback::from(|_| {});
+
+    #[cfg(feature = "client")]
     let on_upload = {
         let file_input = file_input.clone();
         let message = message.clone();

--- a/src/route.rs
+++ b/src/route.rs
@@ -26,6 +26,8 @@ pub enum Route {
     MyUnpublishedPosts,
     #[at("/posts/hidden")]
     HiddenPosts,
+    #[at("/admin/upload-image")]
+    UploadImage,
     #[at("/tag/:slug/:id")]
     Tag { slug: String, id: u64 },
     #[at("/author/:slug")]
@@ -62,6 +64,7 @@ impl Route {
             | Route::UnpublishedPosts
             | Route::MyUnpublishedPosts
             | Route::HiddenPosts
+            | Route::UploadImage
             | Route::Tag { slug: _, id: _ }
             | Route::Author { slug: _ }
             | Route::Authors
@@ -86,6 +89,7 @@ impl Route {
             Route::UnpublishedPosts => html! { <UnpublishedPosts /> },
             Route::MyUnpublishedPosts => html! { <MyUnpublishedPosts /> },
             Route::HiddenPosts => html! { <HiddenPosts /> },
+            Route::UploadImage => html! { <UploadImage /> },
             Route::Tag { slug, id } => html! { <Tag { slug } { id } /> },
             Route::Author { slug } => html! { <Author { slug } /> },
             Route::Authors => html! { <Authors /> },


### PR DESCRIPTION
## Summary
- add `/admin/upload-image` page to upload images and show request result
- expose upload page in left navigation for editors only
- show warning when not authorized to access the upload page
- extend search field and web-sys features for new page
- use editor flag for menu links

## Testing
- `API_URL=http://localhost TITLE=Test DESCRIPTION=Test KEYWORDS=test ACCORDION_JSON='[]' cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68a0849b638c8320ad976eb0b2f42886