### PR TITLE
feat: add purple AI chat

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 
 
 [dependencies]
-blog-generic = { git = "https://github.com/tikitko/blog-server.git", package = "blog-generic" }
+blog-generic = { git = "https://github.com/tikitko/blog-server.git", package = "blog-generic", rev = "423a49a3a6a086a96c391ba58314638fa4b15773" }
 
 log = "0.4"
 async-trait = "0.1"

--- a/index.css
+++ b/index.css
@@ -358,3 +358,40 @@ img {
     padding: 0.5rem;
     width: 100%;
 }
+.ai-chat .card-header {
+    background-color: #6f42c1;
+    color: #fff;
+}
+
+.ai-chat .chat-body {
+    max-height: 200px;
+    overflow-y: auto;
+    background-color: #f8f0ff;
+}
+
+.ai-chat .chat-message {
+    margin-bottom: 4px;
+    padding: 4px 8px;
+    border-radius: 5px;
+}
+
+.ai-chat .chat-message.user {
+    background-color: #e0c9ff;
+    text-align: right;
+}
+
+.ai-chat .chat-message.ai {
+    background-color: #f0e6ff;
+    text-align: left;
+}
+
+.btn-purple {
+    background-color: #6f42c1;
+    color: #fff;
+}
+
+.btn-purple:hover {
+    background-color: #5a359f;
+    color: #fff;
+}
+

--- a/src/components/ai_chat.rs
+++ b/src/components/ai_chat.rs
@@ -1,0 +1,121 @@
+use yew::prelude::*;
+
+#[cfg(feature = "client")]
+use gloo_net::http::Request;
+#[cfg(feature = "client")]
+use wasm_bindgen_futures::spawn_local;
+
+#[cfg(feature = "client")]
+use crate::content;
+use crate::utils::*;
+#[cfg(feature = "client")]
+use blog_generic::entities::{ChatAnswer, ChatQuestion};
+
+#[function_component(AiChat)]
+pub fn ai_chat() -> Html {
+    let messages = use_state(|| Vec::<(bool, String)>::new());
+    let question = use_state(|| String::new());
+    let sending = use_state(|| false);
+
+    let oninput = {
+        let question = question.clone();
+        Callback::from(move |e: InputEvent| {
+            let input: web_sys::HtmlInputElement = e.target_unchecked_into();
+            question.set(input.value());
+        })
+    };
+
+    let send = {
+        let messages = messages.clone();
+        let question = question.clone();
+        let sending = sending.clone();
+        Callback::from(move |_| {
+            if *sending {
+                return;
+            }
+            let q = (*question).trim().to_string();
+            if q.is_empty() {
+                return;
+            }
+
+            messages.set({
+                let mut msgs = (*messages).clone();
+                msgs.push((true, q.clone()));
+                msgs
+            });
+            question.set(String::new());
+            sending.set(true);
+
+            #[cfg(feature = "client")]
+            {
+                let messages = messages.clone();
+                let sending = sending.clone();
+                spawn_local(async move {
+                    let url = format!("{}/chat", crate::API_URL);
+                    let body = serde_json::to_string(&ChatQuestion { question: q }).unwrap();
+                    let resp = Request::post(&url)
+                        .header("Content-Type", "application/json")
+                        .body(body)
+                        .unwrap()
+                        .send()
+                        .await;
+                    if let Ok(resp) = resp {
+                        if let Ok(api) = resp.json::<content::API<ChatAnswer>>().await {
+                            if let Ok(answer) = api.result() {
+                                messages.set({
+                                    let mut msgs = (*messages).clone();
+                                    msgs.push((false, answer.answer));
+                                    msgs
+                                });
+                            }
+                        }
+                    }
+                    sending.set(false);
+                });
+            }
+        })
+    };
+
+    let onclick = {
+        let send = send.clone();
+        Callback::from(move |e: MouseEvent| {
+            e.prevent_default();
+            send.emit(());
+        })
+    };
+
+    let onkeydown = {
+        let send = send.clone();
+        Callback::from(move |e: KeyboardEvent| {
+            if e.key() == "Enter" {
+                e.prevent_default();
+                send.emit(());
+            }
+        })
+    };
+
+    html! {
+        <div class="ai-chat card mt-3 w-100">
+            <div class="card-header">
+                { "AI рекомендации" }
+            </div>
+            <div class="chat-body card-body">
+                {
+                    for (*messages).iter().map(|(is_user, msg)| {
+                        let class = if *is_user {"chat-message user"} else {"chat-message ai"};
+                        html!{ <div class={class}>{ msg }</div> }
+                    })
+                }
+            </div>
+            <div class="card-footer d-flex">
+                <input
+                    class="form-control me-2"
+                    value={(*question).clone()}
+                    {oninput}
+                    {onkeydown}
+                />
+                <button class="btn btn-purple" {onclick} disabled={*sending}>{ "Отправить" }</button>
+            </div>
+        </div>
+    }
+}

--- a/src/components/body.rs
+++ b/src/components/body.rs
@@ -3,6 +3,7 @@ use web_sys::HtmlInputElement;
 use yew::prelude::*;
 use yew_router::prelude::*;
 
+use crate::components::ai_chat::*;
 use crate::components::information_menu::*;
 use crate::components::navigation_menu::*;
 use crate::components::recommended_post::*;
@@ -84,7 +85,8 @@ pub fn body() -> Html {
                         </div>
                         <NavigationMenu />
                     </div>
-                    <div class="d-flex flex-wrap align-items-end justify-content-center">
+                    <div class="d-flex flex-column gap-2 align-items-center justify-content-end">
+                        <AiChat />
                         <p class="mb-0 text-center">
                             <a href="https://github.com/tikitko/blog-ui/blob/main/MADEWITHLOVE.md" class="text-decoration-none">
                                 { "Сделано с ❤️" }

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -1,3 +1,4 @@
+pub mod ai_chat;
 pub mod auth_user_block;
 pub mod author_card;
 pub mod author_image;


### PR DESCRIPTION
## Summary
- integrate blog-generic from PR brewpipeline/blog-server#96
- add purple-themed AI chat for reading tips
- link AI chat from left menu

## Testing
- `API_URL="http://localhost" TITLE="" DESCRIPTION="" KEYWORDS="" ACCORDION_JSON="[]" cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68a230de76848320aa37754ce06e57d0